### PR TITLE
Fix React test heading

### DIFF
--- a/React-Code/src/App.test.js
+++ b/React-Code/src/App.test.js
@@ -1,8 +1,8 @@
 import {render, screen} from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
-  render(<App/>);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+test('renders ToDo List heading', () => {
+  render(<App />);
+  const headingElement = screen.getByText(/ToDo List/i);
+  expect(headingElement).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- update `App.test.js` to look for the **ToDo List** heading

## Testing
- `npm test -- --watchAll=false` *(fails: `react-scripts` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f4e251244833092bd7dfeddc32324